### PR TITLE
Correct classes in form-sizes code blocks

### DIFF
--- a/docs-base.html
+++ b/docs-base.html
@@ -860,7 +860,7 @@
                             <div class="codeBlock">
                                 <pre class="brush: html">
                                     <label for="exampleInputField6">Label Example</label>
-                                    <input type="email" id="exampleInputField6" class="_success" value="...">
+                                    <input type="email" id="exampleInputField6" class="_large" value="...">
                                 </pre>
                             </div>
                             <div class="exampleBlock">
@@ -875,7 +875,7 @@
                             <div class="codeBlock">
                                 <pre class="brush: html">
                                     <label for="exampleInputField7">Label Example</label>
-                                    <input type="text" id="exampleInputField7" class="_warning" placeholder="...">
+                                    <input type="text" id="exampleInputField7" class="_small" placeholder="...">
                                 </pre>
                             </div>
                         </article>


### PR DESCRIPTION
Fixed incorrent classes in `forms-sizes` article code blocks.